### PR TITLE
Pkg to replace fsutils

### DIFF
--- a/debian/android-sdk-ext4-utils.install
+++ b/debian/android-sdk-ext4-utils.install
@@ -1,0 +1,6 @@
+#!/usr/bin/dh-exec
+
+ext4_utils/mkuserimg.sh => usr/bin/mkuserimg
+ext4_utils/ext2simg usr/bin
+ext4_utils/ext4fixup usr/bin
+ext4_utils/make_ext4fs usr/bin

--- a/debian/android-sdk-ext4-utils.manpages
+++ b/debian/android-sdk-ext4-utils.manpages
@@ -1,0 +1,4 @@
+debian/mkuserimg.1
+debian/make_ext4fs.1
+debian/ext4fixup.1
+debian/ext2simg.1

--- a/debian/control
+++ b/debian/control
@@ -7,15 +7,30 @@ Uploaders: Hans-Christoph Steiner <hans@eds.org>,
            Chirayu Desai <chirayudesai1@gmail.com>
 Build-Depends: android-libsparse-dev (>= 1:7.0.0+r33~),
                android-libselinux-dev (>= 7.0.0~),
+	       android-libcutils-dev,
+	       android-libext4-utils-dev,
+	       e2fsprogs,
                android-platform-system-core-headers (>= 1:7.0.0+r33~),
                debhelper (>=10),
                dh-exec,
+	       pandoc,
                libf2fs-dev,
                zlib1g-dev
 Standards-Version: 3.9.8
 Homepage: https://android.googlesource.com/platform/system/extras
 Vcs-Git: https://anonscm.debian.org/git/android-tools/android-platform-system-extras.git
 Vcs-Browser: https://anonscm.debian.org/cgit/android-tools/android-platform-system-extras.git
+
+
+
+Package: android-sdk-ext4-utils
+Architecture: amd64 i386
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Breaks: android-tools-fsutils (<< 6.0~)
+Replaces: android-tools-fsutils (<< 6.0~)
+Description: Android ext4-utils tools
+ Command line tools to make sparse images from ext4 file system images and android images(.img) with ext4 file systems .
+
 
 Package: android-libf2fs-utils
 Section: libs

--- a/debian/ext2simg.1.md
+++ b/debian/ext2simg.1.md
@@ -1,0 +1,20 @@
+% ext2simg android-platform-system-extras | ext2simg Manuals
+% The Android Open Source Project
+
+# NAME
+
+ext2simg - ext to simg
+
+# SYNOPSIS
+
+ext2simg [ options ] <image or block device> <output image>
+
+  -c include CRC block
+  -v verbose output
+  -z gzip output
+  -S don't use sparse output format
+
+# DESCRIPTION
+
+**ext2simg** is a command line tool for converting ext to simg
+

--- a/debian/ext2simg.install
+++ b/debian/ext2simg.install
@@ -1,0 +1,2 @@
+
+ext4_utils/ext2simg usr/bin

--- a/debian/ext2simg.lintian-overrides
+++ b/debian/ext2simg.lintian-overrides
@@ -1,0 +1,12 @@
+# Executables from the Android SDK normally each staticly link in all
+# of the libs.  That means each executable includes a full copy of all
+# the libs, which is not how Debian works.  These libs need to be
+# dynamically linlked in so that just the library can be updated when
+# there is a security fix, instead of requiring all of the executables
+# be recompiled.  That said, these libraries do not have a stable
+# interface and were never intended to be used by any other project,
+# only with the internal, Android SDK executables.  Therefore, the
+# Android SDK executables use private libraries located in
+# /usr/lib/android
+
+binary-or-shlib-defines-rpath

--- a/debian/ext2simg.manpages
+++ b/debian/ext2simg.manpages
@@ -1,0 +1,1 @@
+debian/ext2simg.1

--- a/debian/ext2simg.mk
+++ b/debian/ext2simg.mk
@@ -1,0 +1,16 @@
+NAME = ext2simg
+SOURCES = ext2simg.c
+SOURCES := $(foreach source, $(SOURCES), ext4_utils/$(source))
+CFLAGS +=  -Iext4_utils
+LDFLAGS += -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+           -Wl,-rpath-link=. \
+           -L/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+           -lz -lsparse -lselinux -lext4_utils
+
+build: $(SOURCES)
+	$(CC) $^ -o ext4_utils/$(NAME) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
+
+clean:
+	$(RM) ext4_utils/$(NAME)
+
+

--- a/debian/ext4fixup.1.md
+++ b/debian/ext4fixup.1.md
@@ -1,0 +1,16 @@
+% ext4fixup android-platform-system-extras | ext4fixup Manuals
+% The Android Open Source Project
+
+# NAME
+
+ext4fixup - fixing up ext4
+
+# SYNOPSIS
+
+ext4fixup: usage: ext4fixup [-vn] <image or block device>
+
+
+# DESCRIPTION
+
+**ext4fixup** is a command line tool for fixing up ext4
+

--- a/debian/ext4fixup.install
+++ b/debian/ext4fixup.install
@@ -1,0 +1,1 @@
+ext4_utils/ext4fixup usr/bin

--- a/debian/ext4fixup.lintian-overrides
+++ b/debian/ext4fixup.lintian-overrides
@@ -1,0 +1,12 @@
+# Executables from the Android SDK normally each staticly link in all
+# of the libs.  That means each executable includes a full copy of all
+# the libs, which is not how Debian works.  These libs need to be
+# dynamically linlked in so that just the library can be updated when
+# there is a security fix, instead of requiring all of the executables
+# be recompiled.  That said, these libraries do not have a stable
+# interface and were never intended to be used by any other project,
+# only with the internal, Android SDK executables.  Therefore, the
+# Android SDK executables use private libraries located in
+# /usr/lib/android
+
+binary-or-shlib-defines-rpath

--- a/debian/ext4fixup.manpages
+++ b/debian/ext4fixup.manpages
@@ -1,0 +1,1 @@
+debian/ext4fixup.1

--- a/debian/ext4fixup.mk
+++ b/debian/ext4fixup.mk
@@ -1,0 +1,15 @@
+NAME = ext4fixup
+SOURCES = ext4fixup_main.c
+SOURCES := $(foreach source, $(SOURCES), ext4_utils/$(source)) 
+CFLAGS +=  -Iext4_utils
+LDFLAGS += -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+	   -Wl,-rpath-link=. \
+           -L/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+           -lz -lsparse -lext4_utils
+
+build: $(SOURCES)
+	$(CC) $^ -o ext4_utils/$(NAME) $(CFLAGS) $(LDFLAGS)
+
+clean:
+	$(RM) ext4_utils/$(NAME)
+

--- a/debian/make-ext4fs.install
+++ b/debian/make-ext4fs.install
@@ -1,0 +1,2 @@
+
+ext4_utils/make_ext4fs usr/bin

--- a/debian/make-ext4fs.manpages
+++ b/debian/make-ext4fs.manpages
@@ -1,0 +1,1 @@
+debian/make_ext4fs.1

--- a/debian/make-ext4fs.mk
+++ b/debian/make-ext4fs.mk
@@ -1,0 +1,15 @@
+NAME = make_ext4fs
+SOURCES = make_ext4fs_main.c
+SOURCES := $(foreach source, $(SOURCES), ext4_utils/$(source))
+CFLAGS += -I/usr/include/android/ -DHOST -DANDROID
+LDFLAGS += -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+	   -Wl,-rpath-link=. \
+	   -L/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+           -lz -lselinux -lsparse -lext4_utils -lcutils
+
+build: $(SOURCES)
+	$(CC) $^ -o ext4_utils/$(NAME) $(CFLAGS) $(LDFLAGS)
+
+clean:
+	$(RM) ext4_utils/$(NAME)
+

--- a/debian/make_ext4fs.1.md
+++ b/debian/make_ext4fs.1.md
@@ -1,0 +1,21 @@
+% mkext4fs android-platform-system-extras | mkext4fs Manuals
+% The Android Open Source Project
+
+# NAME
+
+mkext4fs - making ext4 file systems
+
+# SYNOPSIS
+
+mkext4fs [ -l <len> ] [ -j <journal size> ] [ -b <block_size> ]
+    [ -g <blocks per group> ] [ -i <inodes> ] [ -I <inode size> ]
+    [ -L <label> ] [ -f ] [ -a <android mountpoint> ] [ -u ]
+    [ -S file_contexts ] [ -C fs_config ] [ -T timestamp ]
+    [ -z | -s ] [ -w ] [ -c ] [ -J ] [ -v ] [ -B <block_list_file> ]
+    [ -d <base_alloc_file_in> ] [ -D <base_alloc_file_out> ]
+    <filename> [[<directory>] <target_out_directory>]
+
+# DESCRIPTION
+
+**mkext4fs** is a command line tool for make ext4 file systems
+

--- a/debian/mkuserimg.1.md
+++ b/debian/mkuserimg.1.md
@@ -1,0 +1,17 @@
+% mkuserimg android-platform-system-extras | mkuserimg Manuals
+% The Android Open Source Project
+
+# NAME
+
+mkuserimg - make user image of ext4 file systems
+
+# SYNOPSIS
+
+Usage:
+mkuserimg [-s] SRC_DIR OUTPUT_FILE EXT_VARIANT MOUNT_POINT SIZE [-j <journal_size>]
+             [-T TIMESTAMP] [-C FS_CONFIG] [-D PRODUCT_OUT] [-B BLOCK_LIST_FILE] [-d BASE_ALLOC_FILE_IN ] [-A 	BASE_ALLOC_FILE_OUT ] [-L LABEL] [FILE_CONTEXTS
+
+# DESCRIPTION
+
+**mkuserimg** is a command line tool for making user images of ext4 file systems
+

--- a/debian/mkuserimg.install
+++ b/debian/mkuserimg.install
@@ -1,0 +1,3 @@
+#!/usr/bin/dh-exec
+
+ext4_utils/mkuserimg.sh => usr/bin/mkuserimg

--- a/debian/mkuserimg.manpages
+++ b/debian/mkuserimg.manpages
@@ -1,0 +1,1 @@
+debian/mkuserimg.1

--- a/debian/rules
+++ b/debian/rules
@@ -8,21 +8,49 @@ export DEB_CPPFLAGS_MAINT_APPEND = -I/usr/include/android
 export DEB_CFLAGS_MAINT_APPEND = -DNDEBUG
 export DEB_CXXFLAGS_MAINT_APPEND = -DNDEBUG
 
+# If building on architectures other than the supported ones, only build the
+# architecture independent "android-platform-system-core-headers"
+
+
 lib%.so: debian/lib%.mk
 	make -f $<
+
+ext4_utils/ext2simg: debian/ext2simg.mk
+	make -f $<
+
+ext4_utils/ext4fixup: debian/ext4fixup.mk
+	make -f $<
+
+ext4_utils/make-ext4fs: debian/make-ext4fs.mk
+	make -f $<
+
+
 
 %:
 	dh $@
 
+
 override_dh_shlibdeps:
 	dh_shlibdeps -l/usr/lib/$(DEB_HOST_MULTIARCH)/android
 
-override_dh_auto_build: libext4_utils.so libf2fs_utils.so
-
+override_dh_auto_build: ext4_utils/ext2simg \
+		ext4_utils/ext4fixup \
+		ext4_utils/make-ext4fs \
+		libext4_utils.so \
+		libf2fs_utils.so
+	pandoc -s -o debian/make_ext4fs.1 debian/make_ext4fs.1.md
+	pandoc -s -o debian/ext4fixup.1 debian/ext4fixup.1.md
+	pandoc -s -o debian/ext2simg.1 debian/ext2simg.1.md
+	pandoc -s -o debian/mkuserimg.1 debian/mkuserimg.1.md
+		
 override_dh_auto_clean:
 	dh_auto_clean
 	make clean -f debian/libext4_utils.mk
 	make clean -f debian/libf2fs_utils.mk
+	make clean -f debian/ext2simg.mk
+	make clean -f debian/ext4fixup.mk
+	make clean -f debian/make-ext4fs.mk
+	$(RM) debian/*.1
 
 get-orig-source:
 	uscan --download-current-version --force-download


### PR DESCRIPTION
Hi,
I have made the package android-sdk-ext4-utils to replace a few tools on android-tools-fsutils. android-tools-fsutils will be completely replaced only when I finish the packages in android-platform-system-core.
Thanks,
Saif(m36)